### PR TITLE
fix: handle findIndex returning -1 when rewardSystemLevelData is null

### DIFF
--- a/src/ui/pages/home/Profile/ProfileRewardsLevels.tsx
+++ b/src/ui/pages/home/Profile/ProfileRewardsLevels.tsx
@@ -89,7 +89,8 @@ export default function ProfileRewardsLevels(props: ProfileRewardsLevelsProps) {
   };
 
   const handleChangeToCurrentLevel = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    onLevelChange(event, rewardSystemAllLevelsData.findIndex(level => level.identity === rewardSystemLevelData?.identity) + 1);
+    const pageIndex = rewardSystemAllLevelsData.findIndex(level => level.identity === rewardSystemLevelData?.identity);
+    onLevelChange(event, pageIndex === -1 ? 1 : pageIndex + 1);
   };
 
   return (


### PR DESCRIPTION
Due to findIndex returning -1 when rewardSystemLevelData is null, the activeLevelIndex was set to -1 as well in ProfileRewards' handleLevelChange function. This caused the level object to undefined, thus causing exceptions when trying to access its properties. So when the user clicked "Return to Current Level" button, while page was loading its data, an error was shown, which is now handled correctly and user remains on page 1 until the data is fetched.

fixes #3 [Bug] When clicking "Return to Current Level" while data is loading in the Rewards Page an error is shown to the user.